### PR TITLE
feat(plugin): create total count plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,9 @@
 {
-  extends: "lob"
+  extends: "lob",
+  globals: {
+    expect: false
+  },
+  rules: {
+    arrow-body-style: 0
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# SQLite databases
+*.sqlite3

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const Bluebird = require('bluebird');
+const Joi      = require('joi');
+
+const Validator = require('./validator');
+
+const RADIX = 10;
+
+exports.register = (server, options, next) => {
+
+  server.ext('onPreResponse', (request, reply) => {
+
+    const settings = request.route.settings.plugins.totalCount;
+    const credentials = request.auth.credentials;
+    const validation = Joi.validate(request, Validator, { allowUnknown: true });
+
+    if (!settings || validation.error) {
+      return reply.continue();
+    }
+
+    return Bluebird.resolve(settings.model)
+    .then((Model) => {
+      if (typeof Model.prototype.filter === 'function') {
+        return new Model().filter(request.query.filter, credentials).count('*');
+      }
+      return new Model().count('*');
+    })
+    .then((count) => {
+      request.response.source.total_count = parseInt(count, RADIX);
+      reply.continue();
+    })
+    .catch((err) => reply(err));
+  });
+
+  next();
+
+};
+
+exports.register.attributes = {
+  pkg: require('../package.json')
+};

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = {
+  query: Joi.object().keys({
+    include: Joi.array().items(Joi.string().valid('total_count').required(), Joi.any()).required()
+  }),
+  response: Joi.object().keys({
+    source: Joi.object().required()
+  })
+};

--- a/package.json
+++ b/package.json
@@ -27,12 +27,26 @@
     "url": "https://github.com/lob/hapi-bookshelf-total-count/issues"
   },
   "homepage": "https://github.com/lob/hapi-bookshelf-total-count#readme",
+  "peerDependencies": {
+    "bookshelf": ">=0.8.2",
+    "hapi": "11.x"
+  },
+  "dependencies": {
+    "bluebird": "^3.3.4",
+    "joi": "^8.0.5"
+  },
   "devDependencies": {
+    "bookshelf": "^0.9.4",
+    "chai": "^3.0.0",
     "eslint": "^1.9.0",
     "eslint-config-lob": "^2.0.0",
     "generate-changelog": "^1.0.0",
-    "chai": "^3.0.0",
+    "hapi": "^11.1.2",
+    "hapi-query-filter": "^1.0.1",
+    "inject-then": "^2.0.5",
     "istanbul": "^0.4.2",
-    "mocha": "^2.2.5"
+    "knex": "^0.10.0",
+    "mocha": "^2.2.5",
+    "sqlite3": "^3.1.2"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,238 @@
+'use strict';
+
+const Knex      = require('knex')({
+  client: 'sqlite3',
+  connection: {
+    filename: './test/test.sqlite3'
+  },
+  useNullAsDefault: true
+});
+const Bluebird  = require('bluebird');
+const Bookshelf = require('bookshelf')(Knex);
+const Hapi      = require('hapi');
+
+const Book  = Bookshelf.Model.extend({
+  tableName: 'books',
+  filter: function (filter) {
+    return this.query((qb) => {
+      if (filter.year) {
+        qb.where('year', filter.year);
+      }
+    });
+  }
+});
+const Genre = Bookshelf.Model.extend({ tableName: 'genres' });
+
+const handler = (request, reply) => {
+  reply({});
+};
+
+describe('plugin', () => {
+
+  let server;
+
+  before(() => {
+    return Bluebird.all([
+      Knex.schema.dropTableIfExists('books'),
+      Knex.schema.dropTableIfExists('genres')
+    ])
+    .then(() => {
+      return Bluebird.all([
+        Knex.schema.createTable('books', (table) => {
+          table.increments();
+          table.string('name');
+          table.integer('year');
+        }),
+        Knex.schema.createTable('genres', (table) => {
+          table.increments();
+          table.string('name');
+        })
+      ]);
+    })
+    .then(() => {
+      return Bluebird.all([
+        Knex('books').insert([
+          { name: 'Surely You\'re Joking, Mr. Feynman!', year: 1984 },
+          { name: 'Sister Outsider', year: 1984 },
+          { name: 'Season of the Witch', year: 2013 }
+        ]),
+        Knex('genres').insert([
+          { name: 'Feminism' },
+          { name: 'History' },
+          { name: 'Science' }
+        ])
+      ]);
+    });
+  });
+
+  beforeEach(() => {
+    server = new Hapi.Server();
+    server.connection({ port: 80 });
+    server.register([
+      require('inject-then'),
+      {
+        register: require('hapi-query-filter'),
+        options: { ignoredKeys: ['include'] }
+      },
+      require('../lib')
+    ], () => {});
+  });
+
+  it('appends the total for models that have a filter function', () => {
+    server.route({
+      method: 'GET',
+      path: '/books',
+      config: {
+        plugins: {
+          queryFilter: { enabled: true },
+          totalCount: { model: Book }
+        },
+        handler
+      }
+    });
+
+    return server.injectThen({
+      method: 'GET',
+      url: '/books?year=1984&include[]=total_count',
+      credentials: {}
+    })
+    .then((res) => {
+      expect(res.result.total_count).to.eql(2);
+    });
+  });
+
+  it('appends the total for models that do not have a filter function', () => {
+    server.route({
+      method: 'GET',
+      path: '/genres',
+      config: {
+        plugins: {
+          totalCount: { model: Genre }
+        },
+        handler
+      }
+    });
+
+    return server.injectThen({
+      method: 'GET',
+      url: '/genres?include[]=total_count',
+      credentials: {}
+    })
+    .then((res) => {
+      expect(res.result.total_count).to.eql(3);
+    });
+  });
+
+  it('appends the total when used with the hapi-query-filter plugin', () => {
+    server.route({
+      method: 'GET',
+      path: '/books',
+      config: {
+        plugins: {
+          queryFilter: { enabled: true },
+          totalCount: { model: Book }
+        },
+        handler
+      }
+    });
+
+    return server.injectThen({
+      method: 'GET',
+      url: '/books?year=1984&include[]=total_count',
+      credentials: {}
+    })
+    .then((res) => {
+      expect(res.result.total_count).to.eql(2);
+    });
+  });
+
+  it('appends the unfiltered total when used without the hapi-query-filter plugin', () => {
+    server.route({
+      method: 'GET',
+      path: '/genres',
+      config: {
+        plugins: {
+          queryFilter: { enabled: false },
+          totalCount: { model: Genre }
+        },
+        handler
+      }
+    });
+
+    return server.injectThen({
+      method: 'GET',
+      url: '/genres?include[]=total_count',
+      credentials: {}
+    })
+    .then((res) => {
+      expect(res.result.total_count).to.eql(3);
+    });
+  });
+
+  it('does not append the total when the plugin is disabled', () => {
+    server.route({
+      method: 'GET',
+      path: '/books',
+      config: {
+        plugins: {},
+        handler
+      }
+    });
+
+    return server.injectThen({
+      method: 'GET',
+      url: '/books?include[]=total_count',
+      credentials: {}
+    })
+    .then((res) => {
+      expect(res.statusCode).to.eql(200);
+      expect(res.result).to.not.have.property('total_count');
+    });
+  });
+
+  it('does not append the total when request validation is not met', () => {
+    server.route({
+      method: 'GET',
+      path: '/books',
+      config: {
+        plugins: {
+          totalCount: { model: Book }
+        },
+        handler
+      }
+    });
+
+    return server.injectThen({
+      method: 'GET',
+      url: '/books',
+      credentials: {}
+    })
+    .then((res) => {
+      expect(res.statusCode).to.eql(200);
+      expect(res.result).to.not.have.property('total_count');
+    });
+  });
+
+  it('errors on incorrect initialization', () => {
+    server.route({
+      method: 'GET',
+      path: '/books',
+      config: {
+        plugins: {
+          totalCount: { model: null }
+        },
+        handler
+      }
+    });
+
+    return server.injectThen({
+      method: 'GET',
+      url: '/books?include[]=total_count',
+      credentials: {}
+    })
+    .then((res) => {
+      expect(res.statusCode).to.eql(500);
+    });
+  });
+
+});

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const Joi = require('joi');
+
+const Validator = require('../lib/validator');
+
+describe('validator', () => {
+
+  const options = { allowUnknown: true };
+
+  it('requires "include" array with total_count', () => {
+    const request = {
+      query: { include: ['total_amount'] },
+      response: { source: {} }
+    };
+    const result = Joi.validate(request, Validator, options);
+
+    expect(result.error).to.match(/"include" does not contain 1 required value/);
+  });
+
+  it('requires a response source object', () => {
+    const request = {
+      query: { include: ['total_count'] },
+      response: { source: null }
+    };
+    const result = Joi.validate(request, Validator, options);
+
+    expect(result.error).to.match(/"source" must be an object/);
+  });
+
+});


### PR DESCRIPTION
### What

Creates a total count plugin to be used with Hapi, Bookshelf, and [hapi-query-filter](https://github.com/lob/hapi-query-filter) though it will work without [hapi-query-filter](https://github.com/lob/hapi-query-filter) if you just want an absolute total count without any filtering. 
### Why

So we can decouple it from the Lob API and potentially reuse it with new Hapi APIs.
### Notes
- See inline comments for specific notes. 
- There are ways to make this plugin more accessible and configurable but I'm keeping it as is for the first iteration since it's already so specific (only for Hapi and Bookshelf users). 
- The diff is larger than it really is because each test is so long (register the route, then hit the endpoint). I'll still create the README in a separate PR to keep this one at 300 changes.
