### PR TITLE
MI-471: Add missing name property to plugin export

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,5 +61,6 @@ function register (server, options) {
 
 exports.plugin = {
   pkg: require('../package.json'),
+  name: 'hapi-bookshelf-total-count',
   register
 };


### PR DESCRIPTION
## What

Fixes an error installing the plugin due to a missing name attribute.