### PR TITLE
bug(PLAT-2937) - Add redis service to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,20 @@ jobs:
     permissions:
       id-token: write # Required for publishing using OIDC authentication
       contents: write
+
+    services:
+      redis:
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps port 6379 on service container to the host
+          - 6379:6379
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

publish failed because of a test timeout.

## Solution

- Add in the redis service to the workflow.